### PR TITLE
V2.0.0 beta.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -279,9 +279,9 @@ checksum = "6fb8d784f27acf97159b40fc4db5ecd8aa23b9ad5ef69cdd136d3bc80665f0c0"
 
 [[package]]
 name = "h2"
-version = "0.3.21"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91fc23aa11be92976ef4729127f1a74adf36d8436f7816b185d18df956790833"
+checksum = "bb2c4422095b67ee78da96fbb51a4cc413b3b25883c7717ff7ca1ab31022c9c9"
 dependencies = [
  "bytes",
  "fnv",
@@ -289,7 +289,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http",
- "indexmap 1.9.3",
+ "indexmap 2.0.2",
  "slab",
  "tokio",
  "tokio-util",
@@ -865,9 +865,9 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.10.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d560933a0de61cf715926b9cac824d4c883c2c43142f787595e48280c40a1d0e"
+checksum = "76c4eb7a4e9ef9d4763600161f12f5070b92a578e1b634db88a6887844c91a13"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -892,9 +892,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-build"
-version = "0.10.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d021fc044c18582b9a2408cd0dd05b1596e3ecdb5c4df822bb0183545683889"
+checksum = "be4ef6dd70a610078cb4e338a0f79d06bc759ff1b22d2120c2ff02ae264ba9c2"
 dependencies = [
  "prettyplease",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ path = "./tests/build.rs"
 
 [dependencies]
 bytes = "1.5.0"
-tonic = "0.10.2"
+tonic = "0.11.0"
 prost = "0.12.1"
-tonic-build = "0.10.2"
+tonic-build = "0.11.0"
 uuid = "1.5.0"

--- a/aruna/api/dataproxy/services/v2/bundler_service.proto
+++ b/aruna/api/dataproxy/services/v2/bundler_service.proto
@@ -45,6 +45,7 @@ message CreateBundleRequest {
     repeated string resource_ids = 1;
     string filename = 2; // .tar.gz / .zip
     google.protobuf.Timestamp expires_at = 3; // Default 1 Month
+    bool once = 4; // Default false (expires after first download)
 }
 
 message CreateBundleResponse {

--- a/aruna/api/dataproxy/services/v2/dataproxy_service.proto
+++ b/aruna/api/dataproxy/services/v2/dataproxy_service.proto
@@ -74,6 +74,21 @@ service DataproxyUserService {
             body : "*"
         };
     }
+
+
+    // RevokeCredentials
+    //
+    // Status: BETA
+    //
+    // Authorized method that needs a aruna-token
+    // Revokes the current credentials
+    rpc RevokeCredentials(RevokeCredentialsRequest) returns (RevokeCredentialsResponse) {
+        option (google.api.http) = {
+            delete : "/v2/credentials"
+        };
+    }
+
+
     // PushReplica
     //
     // Status: UNIMPLEMENTED
@@ -223,6 +238,10 @@ message CreateOrUpdateCredentialsResponse {
     string access_key = 1;
     string secret_key = 2;
 }
+
+message RevokeCredentialsRequest {}
+
+message RevokeCredentialsResponse {}
 
 message S3Path {
     string bucket = 1;

--- a/aruna/api/dataproxy/services/v2/dataproxy_service.proto
+++ b/aruna/api/dataproxy/services/v2/dataproxy_service.proto
@@ -182,9 +182,9 @@ message PullReplicationRequest {
 // Messages (responses) from PROXY A
 message ObjectInfo {
     string object_id = 1;
-    int64 chunks = 2;
+    int64 chunks = 2; // == (Compressed_size / (65536 + 28)) + 1
     int64 raw_size  = 3;
-    repeated uint32 block_list = 4;
+    int64 compressed_size = 4;
     optional string extra = 5; // JSON encoded proxy specific extra fields
 }
 

--- a/aruna/api/dataproxy/services/v2/dataproxy_service.proto
+++ b/aruna/api/dataproxy/services/v2/dataproxy_service.proto
@@ -109,7 +109,7 @@ service DataproxyUserService {
     }
 }
 
-service DataproxyUserIngestion {
+service DataproxyIngestionService {
     option (google.api.api_visibility).restriction = "PROXY";
     // IngestExistingObject
     //

--- a/aruna/api/dataproxy/services/v2/dataproxy_service.proto
+++ b/aruna/api/dataproxy/services/v2/dataproxy_service.proto
@@ -57,6 +57,18 @@ service DataproxyUserService {
     // specific S3AccessKey and S3SecretKey
     rpc GetCredentials(GetCredentialsRequest) returns (GetCredentialsResponse) {
         option (google.api.http) = {
+            get : "/v2/credentials"
+        };
+    }
+
+    // CreateOrUpdateCredentials
+    //
+    // Status: BETA
+    //
+    // Authorized method that needs a aruna-token to exchange for dataproxy
+    // specific S3AccessKey and S3SecretKey
+    rpc CreateOrUpdateCredentials(CreateOrUpdateCredentialsRequest) returns (CreateOrUpdateCredentialsResponse) {
+        option (google.api.http) = {
             post : "/v2/credentials"
             body : "*"
         };
@@ -188,6 +200,14 @@ message PushReplicationResponse {
 message GetCredentialsRequest {}
 
 message GetCredentialsResponse {
+    string access_key = 1;
+    string secret_key = 2;
+}
+
+message CreateOrUpdateCredentialsRequest {
+}
+
+message CreateOrUpdateCredentialsResponse {
     string access_key = 1;
     string secret_key = 2;
 }

--- a/aruna/api/dataproxy/services/v2/dataproxy_service.proto
+++ b/aruna/api/dataproxy/services/v2/dataproxy_service.proto
@@ -8,6 +8,7 @@ option java_outer_classname = "DataProxyService";
 
 import "google/api/annotations.proto";
 import "google/api/visibility.proto";
+import "aruna/api/storage/models/v2/models.proto";
 
 // DataproxyService
 //
@@ -26,7 +27,7 @@ service DataproxyReplicationService {
     
     // InitReplication
     //
-    // Status: ALPHA
+    // Status: UNIMPLEMENTED
     //
     // Provides the necessary url to init replication
     rpc PushReplication(PushReplicationRequest) returns (PushReplicationResponse) {}
@@ -75,7 +76,7 @@ service DataproxyUserService {
     }
     // PushReplica
     //
-    // Status: BETA
+    // Status: UNIMPLEMENTED
     //
     // Manually transfers a replica to another data-proxy
     rpc PushReplica(PushReplicaRequest) returns (PushReplicaResponse) {
@@ -86,7 +87,7 @@ service DataproxyUserService {
     }
     // PullReplica
     //
-    // Status: BETA
+    // Status: UNIMPLEMENTED
     //
     // Manually request data to be transferred to this data-proxy
     rpc PullReplica(PullReplicaRequest) returns (PullReplicaResponse) {
@@ -95,9 +96,10 @@ service DataproxyUserService {
             body : "*"
         };
     }
-    // PullReplica
+
+    // ReplicationStatus
     //
-    // Status: BETA
+    // Status: UNIMPLEMENTED
     //
     // Status of the previous replication request
     rpc ReplicationStatus(ReplicationStatusRequest) returns (ReplicationStatusResponse) {
@@ -105,6 +107,16 @@ service DataproxyUserService {
             get : "/v2/replica/{replication_id}/status"
         };
     }
+}
+
+service DataproxyUserIngestion {
+    option (google.api.api_visibility).restriction = "PROXY";
+    // IngestExistingObject
+    //
+    // Status: ALPHA
+    //
+    // Ingest an existing object into backend
+    rpc IngestExistingObject(IngestExistingObjectRequest) returns (IngestExistingObjectResponse) {}
 }
 
 
@@ -344,6 +356,45 @@ message InitLocationRequest {
 
 message InitLocationResponse {
     ObjectLocation location = 1;
+}
+
+message IngestResource {
+  // object name
+  string name = 1;
+  // title
+  string title = 2;
+  // description
+  string description = 3;
+  // Authors
+  repeated storage.models.v2.Author authors = 4;
+  // object specific labels / hooks
+  repeated storage.models.v2.KeyValue key_values = 5;
+  // Internal / External relations (URLs / IDs from external sources)
+  repeated storage.models.v2.Relation relations = 6;
+  // DataClass
+  storage.models.v2.DataClass data_class = 7;
+  // Ignored if Collection | Dataset
+  repeated storage.models.v2.Hash hashes = 8;
+  string metadata_license_tag = 9;
+  string data_license_tag = 10;
+}
+
+message IngestExistingObjectRequest {
+    string project_id = 1;
+    oneof collection {
+        string collection_id = 2;
+        IngestResource collection_resource = 3;
+    }
+    oneof dataset {
+        string dataset_id = 4;
+        IngestResource dataset_resource = 5;
+    }
+    IngestResource object = 6;
+    string path = 7; // "s3://bucket/key" or "file:///foo/bar/baz.txt" must be a valid file
+}
+
+message IngestExistingObjectResponse {
+    string object_id = 1;
 }
 
 

--- a/aruna/api/storage/models/v2/models.proto
+++ b/aruna/api/storage/models/v2/models.proto
@@ -342,7 +342,7 @@ message Project {
 message Collection {
   string id = 1; // ASDASDASDOPASKIDPO
   string name = 2; // my_mags
-  string title = 15; // Long name
+  string title = 15;
   string description = 3; // ENA asda234928349028 MAG 1293819203819028i V1
   // Collection specific labels / hooks
   repeated KeyValue key_values = 4;

--- a/aruna/api/storage/models/v2/models.proto
+++ b/aruna/api/storage/models/v2/models.proto
@@ -141,6 +141,9 @@ message User {
   string email = 5;
   // User attributes
   UserAttributes attributes = 6;
+  // First and Last name
+  string first_name = 7;
+  string last_name = 8;
 }
 
 message Permission {
@@ -289,6 +292,19 @@ message License {
   string url = 4; // https://creativecommons.org/licenses/by-sa/4.0/
 }
 
+message Author {
+  string first_name = 1;
+  string last_name = 2;
+  optional string email = 3;
+  optional string orcid = 4;
+  optional string id = 5;
+}
+
+message RuleBinding {
+  string rule_id = 1;
+  string origin = 2;
+}
+
 // ------ Resources ----------
 
 message GenericResource {
@@ -303,6 +319,7 @@ message GenericResource {
 message Project {
   string id = 1;
   string name = 2; // Short name according to BucketNamingRules
+  string title = 15; // Long name
   string description = 3; // Long name
   // Project specific labels / hooks
   repeated KeyValue key_values = 4;
@@ -312,17 +329,20 @@ message Project {
   DataClass data_class = 7;
   google.protobuf.Timestamp created_at = 8;
   string created_by = 9;
+  repeated Author authors = 16;
   Status status = 10;
   bool dynamic = 11;
   repeated DataEndpoint endpoints = 12;
   string metadata_license_tag = 13;
   string default_data_license_tag = 14;
+  repeated RuleBinding rule_bindings = 17;
 }
 
 
 message Collection {
   string id = 1; // ASDASDASDOPASKIDPO
   string name = 2; // my_mags
+  string title = 15; // Long name
   string description = 3; // ENA asda234928349028 MAG 1293819203819028i V1
   // Collection specific labels / hooks
   repeated KeyValue key_values = 4;
@@ -332,16 +352,19 @@ message Collection {
   DataClass data_class = 7;
   google.protobuf.Timestamp created_at = 8;
   string created_by = 9;
+  repeated Author authors = 16;
   Status status = 10;
   bool dynamic = 11;
   repeated DataEndpoint endpoints = 12;
   string metadata_license_tag = 13;
   string default_data_license_tag = 14;
+  repeated RuleBinding rule_bindings = 17;
 }
 
 message Dataset {
   string id = 1;
   string name = 2;
+  string title = 15; // Long name
   string description = 3;
   // Dataset specific labels / hooks
   repeated KeyValue key_values = 4;
@@ -351,16 +374,19 @@ message Dataset {
   DataClass data_class = 7;
   google.protobuf.Timestamp created_at = 8;
   string created_by = 9;
+  repeated Author authors = 16;
   Status status = 10;
   bool dynamic = 11;
   repeated DataEndpoint endpoints = 12;
   string metadata_license_tag = 13;
   string default_data_license_tag = 14;
+  repeated RuleBinding rule_bindings = 17;
 }
 
 message Object {
   string id = 1;
   string name = 2;
+  string title = 16; // Long name
   string description = 3;
   // Collection specific labels / hooks
   repeated KeyValue key_values = 4;
@@ -370,6 +396,7 @@ message Object {
   DataClass data_class = 7;
   google.protobuf.Timestamp created_at = 8;
   string created_by = 9;
+  repeated Author authors = 17;
   Status status = 10;
   bool dynamic = 11;
   repeated DataEndpoint endpoints = 12;
@@ -377,4 +404,5 @@ message Object {
   repeated Hash hashes = 13;  
   string metadata_license_tag = 14;
   string data_license_tag = 15;
+  repeated RuleBinding rule_bindings = 18;
 }

--- a/aruna/api/storage/models/v2/models.proto
+++ b/aruna/api/storage/models/v2/models.proto
@@ -171,9 +171,16 @@ message Pubkey {
   string location = 3;
 }
 
-message CustomAttributes {
+message CustomAttribute {
   string attribute_name = 1;
   string attribute_value = 2;
+}
+
+message DataProxyAttribute {
+  string attribute_name = 1;
+  string attribute_value = 2;
+  string signature = 3;
+  string proxy_id = 4;
 }
 
 message OidcMapping {
@@ -186,9 +193,11 @@ message UserAttributes {
   bool service_account = 2;
   repeated Token tokens = 3;
   repeated string trusted_endpoints = 4;
-  repeated CustomAttributes custom_attributes = 5; 
+  repeated CustomAttribute custom_attributes = 5; 
   repeated Permission personal_permissions = 6;
   repeated OidcMapping external_ids = 7;
+  string pubkey = 8;
+  repeated DataProxyAttribute data_proxy_attributes = 9;
 }
 
 // --------------- RELATION / KEYVALUES -------------------

--- a/aruna/api/storage/services/v2/collection_service.proto
+++ b/aruna/api/storage/services/v2/collection_service.proto
@@ -136,11 +136,37 @@ service CollectionService {
       body : "*"
     };
   }
+
+  // UpdateTitle
+  //
+  // Status: ALPHA
+  //
+  // Updates the collections metadata title.
+  rpc UpdateCollectionTitle(UpdateCollectionTitleRequest) returns (UpdateCollectionTitleResponse) {
+    option (google.api.http) = {
+      patch : "/v2/collections/{collection_id}/title"
+      body : "*"
+    };
+  }
+
+
+  // UpdateAuthors
+  //
+  // Status: ALPHA
+  //
+  // Updates the collections metadata title.
+  rpc UpdateCollectionAuthors(UpdateCollectionAuthorsRequest) returns (UpdateCollectionAuthorsResponse) {
+    option (google.api.http) = {
+      patch : "/v2/collections/{collection_id}/authors"
+      body : "*"
+    };
+  }
 }
 
 message CreateCollectionRequest {
   // collection name
   string name = 1;
+  string title = 9;
   // description
   string description = 2;
   // collection specific labels / hooks
@@ -155,6 +181,7 @@ message CreateCollectionRequest {
   }
   optional string metadata_license_tag = 7;
   optional string default_data_license_tag = 8;
+  repeated storage.models.v2.Author authors = 10;
 }
 
 message CreateCollectionResponse {
@@ -240,5 +267,24 @@ message UpdateCollectionLicensesRequest {
 }
 
 message UpdateCollectionLicensesResponse {
+  storage.models.v2.Collection collection = 1;
+}
+
+message UpdateCollectionTitleRequest {
+  string collection_id = 1;
+  string title = 2;
+}
+
+message UpdateCollectionTitleResponse {
+  storage.models.v2.Collection collection = 1;
+}
+
+message UpdateCollectionAuthorsRequest {
+  string collection_id = 1;
+  repeated storage.models.v2.Author add_authors = 2;
+  repeated storage.models.v2.Author remove_authors = 3;
+}
+
+message UpdateCollectionAuthorsResponse {
   storage.models.v2.Collection collection = 1;
 }

--- a/aruna/api/storage/services/v2/dataset_service.proto
+++ b/aruna/api/storage/services/v2/dataset_service.proto
@@ -134,11 +134,37 @@ service DatasetService {
       body : "*"
     };
   }
+
+  // UpdateTitle
+  //
+  // Status: ALPHA
+  //
+  // Updates the datasets metadata title.
+  rpc UpdateDatasetTitle(UpdateDatasetTitleRequest) returns (UpdateDatasetTitleResponse) {
+    option (google.api.http) = {
+      patch : "/v2/datasets/{dataset_id}/title"
+      body : "*"
+    };
+  }
+
+
+  // UpdateAuthors
+  //
+  // Status: ALPHA
+  //
+  // Updates the datasets metadata title.
+  rpc UpdateDatasetAuthors(UpdateDatasetAuthorsRequest) returns (UpdateDatasetAuthorsResponse) {
+    option (google.api.http) = {
+      patch : "/v2/dataset/{dataset_id}/authors"
+      body : "*"
+    };
+  }
 }
 
 message CreateDatasetRequest {
   // dataset name
   string name = 1;
+  string title = 10;
   // Description
   string description = 2;
   // dataset specific labels / hooks
@@ -154,6 +180,7 @@ message CreateDatasetRequest {
   }
   optional string metadata_license_tag = 8;
   optional string default_data_license_tag = 9;
+  repeated storage.models.v2.Author authors = 11;
 }
 
 message CreateDatasetResponse {
@@ -239,5 +266,24 @@ message UpdateDatasetLicensesRequest {
 }
 
 message UpdateDatasetLicensesResponse {
+  storage.models.v2.Dataset dataset = 1;
+}
+
+message UpdateDatasetTitleRequest {
+  string dataset_id = 1;
+  string title = 2;
+}
+
+message UpdateDatasetTitleResponse {
+  storage.models.v2.Dataset dataset = 1;
+}
+
+message UpdateDatasetAuthorsRequest {
+  string dataset_id = 1;
+  repeated storage.models.v2.Author add_authors = 2;
+  repeated storage.models.v2.Author remove_authors = 3;
+}
+
+message UpdateDatasetAuthorsResponse {
   storage.models.v2.Dataset dataset = 1;
 }

--- a/aruna/api/storage/services/v2/object_service.proto
+++ b/aruna/api/storage/services/v2/object_service.proto
@@ -162,6 +162,20 @@ service ObjectService {
       body : "*"
     };
   }
+
+  // SetObjectHashes
+  //
+  // Status: ALPHA
+  //
+  // This method sets the object hashes if not already set
+  // if a hash is already set, it will be compared to the new hash and
+  // set the status to ERROR if they do not match
+  rpc SetObjectHashes(SetObjectHashesRequest) returns (SetObjectHashesResponse) {
+    option (google.api.http) = {
+      post : "/v2/objects/{object_id}/hashes"
+      body : "*"
+    };
+  }
 }
 
 // Models
@@ -370,5 +384,17 @@ message UpdateObjectAuthorsRequest {
 
 message UpdateObjectAuthorsResponse {
   // The updated object
+  storage.models.v2.Object object = 1;
+}
+
+message SetObjectHashesRequest {
+  // Object id
+  string object_id = 1;
+  // Hashes
+  repeated storage.models.v2.Hash hashes = 2;
+}
+
+message SetObjectHashesResponse {
+  // The updated object (possibly with error status)
   storage.models.v2.Object object = 1;
 }

--- a/aruna/api/storage/services/v2/object_service.proto
+++ b/aruna/api/storage/services/v2/object_service.proto
@@ -138,6 +138,30 @@ service ObjectService {
       get : "/v2/objects"
     };
   }
+
+  // UpdateTitle
+  //
+  // Status: ALPHA
+  //
+  // This method updates the title of an object
+  rpc UpdateObjectTitle(UpdateObjectTitleRequest) returns (UpdateObjectTitleResponse) {
+    option (google.api.http) = {
+      post : "/v2/objects/{object_id}/title"
+      body : "*"
+    };
+  }
+
+  // UpdateAuthors
+  //
+  // Status: ALPHA
+  //
+  // This method updates the authors of an object
+  rpc UpdateObjectAuthors(UpdateObjectAuthorsRequest) returns (UpdateObjectAuthorsResponse) {
+    option (google.api.http) = {
+      post : "/v2/objects/{object_id}/authors"
+      body : "*"
+    };
+  }
 }
 
 // Models
@@ -147,6 +171,8 @@ service ObjectService {
 message CreateObjectRequest {
   // collection name
   string name = 1;
+  // title
+  string title = 12;
   // description
   string description = 2;
   // collection specific labels / hooks
@@ -164,6 +190,7 @@ message CreateObjectRequest {
   repeated storage.models.v2.Hash hashes = 9;
   string metadata_license_tag = 10;
   string data_license_tag = 11;
+  repeated storage.models.v2.Author authors = 13;
 }
 
 message CreateObjectResponse {
@@ -318,4 +345,30 @@ message GetObjectEndpointsRequest {
   string collection_id = 1;
   // Object id
   string object_id = 2;
+}
+
+message UpdateObjectTitleRequest {
+  // Object id
+  string object_id = 1;
+  // New title
+  string title = 2;
+}
+
+message UpdateObjectTitleResponse {
+  // The updated object
+  storage.models.v2.Object object = 1;
+}
+
+message UpdateObjectAuthorsRequest {
+  // Object id
+  string object_id = 1;
+  // Add authors
+  repeated storage.models.v2.Author add_authors = 2;
+  // Remove authors
+  repeated storage.models.v2.Author remove_authors = 3;
+}
+
+message UpdateObjectAuthorsResponse {
+  // The updated object
+  storage.models.v2.Object object = 1;
 }

--- a/aruna/api/storage/services/v2/project_service.proto
+++ b/aruna/api/storage/services/v2/project_service.proto
@@ -164,6 +164,29 @@ service ProjectService {
       body : "*"
     };
   }
+  // UpdateTitle
+  //
+  // Status: ALPHA
+  //
+  // This method updates the title of a project
+  rpc UpdateProjectTitle(UpdateProjectTitleRequest) returns (UpdateProjectTitleResponse) {
+    option (google.api.http) = {
+      post : "/v2/project/{project_id}/title"
+      body : "*"
+    };
+  }
+
+  // UpdateAuthors
+  //
+  // Status: ALPHA
+  //
+  // This method updates the authors of an object
+  rpc UpdateProjectAuthors(UpdateProjectAuthorsRequest) returns (UpdateProjectAuthorsResponse) {
+    option (google.api.http) = {
+      post : "/v2/project/{project_id}/authors"
+      body : "*"
+    };
+  }
 }
 
 message CreateProjectRequest {
@@ -271,5 +294,30 @@ message UpdateProjectLicensesRequest {
 }
 
 message UpdateProjectLicensesResponse {
+  storage.models.v2.Project project = 1;
+}
+message UpdateProjectTitleRequest {
+  // Project id
+  string project_id = 1;
+  // New title
+  string title = 2;
+}
+
+message UpdateProjectTitleResponse {
+  // The updated object
+  storage.models.v2.Project project = 1;
+}
+
+message UpdateProjectAuthorsRequest {
+  // Project id
+  string project_id = 1;
+  // Add authors
+  repeated storage.models.v2.Author add_authors = 2;
+  // Remove authors
+  repeated storage.models.v2.Author remove_authors = 3;
+}
+
+message UpdateProjectAuthorsResponse {
+  // The updated project
   storage.models.v2.Project project = 1;
 }

--- a/aruna/api/storage/services/v2/project_service.proto
+++ b/aruna/api/storage/services/v2/project_service.proto
@@ -192,6 +192,8 @@ service ProjectService {
 message CreateProjectRequest {
   // Project name
   string name = 1;
+  // title
+  string title = 9;
   // Description
   string description = 2;
   // Project specific labels / hooks
@@ -205,6 +207,7 @@ message CreateProjectRequest {
   // 
   string metadata_license_tag = 7;
   string default_data_license_tag = 8;
+  repeated storage.models.v2.Author authors = 10;
 }
 
 message CreateProjectResponse {

--- a/aruna/api/storage/services/v2/rules_service.proto
+++ b/aruna/api/storage/services/v2/rules_service.proto
@@ -5,7 +5,6 @@ option go_package = "github.com/ArunaStorage/go-api/v2/aruna/api/storage/service
 option java_multiple_files = true;
 option java_package = "com.github.ArunaStorage.java_api.aruna.api.storage.services.v2";
 option java_outer_classname = "RulesService";
-import "aruna/api/storage/models/v2/models.proto";
 import "google/api/annotations.proto";
 
 

--- a/aruna/api/storage/services/v2/rules_service.proto
+++ b/aruna/api/storage/services/v2/rules_service.proto
@@ -87,7 +87,7 @@ service RulesService {
   rpc CreateRuleBinding(CreateRuleBindingRequest)
     returns (CreateRuleBindingResponse) {
       option (google.api.http) = {
-        post : "/v2/rules/{id}/bindings"
+        post : "/v2/rules/{rule_id}/bindings"
         body : "*"
       };
   }
@@ -100,7 +100,7 @@ service RulesService {
   rpc DeleteRuleBinding(DeleteRuleBindingRequest)
     returns (DeleteRuleBindingResponse) {
       option (google.api.http) = {
-        delete : "/v2/rules/{id}/bindings/{object_id}"
+        delete : "/v2/rules/{rule_id}/bindings/{object_id}"
       };
   }
 }
@@ -122,10 +122,10 @@ message GetRuleRequest {
 
 message Rule {
     string id = 1;
-    string rule = 1;
-    string description = 2;
-    bool public = 3;
-    string owner = 4;
+    string rule = 2;
+    string description = 3;
+    bool public = 4;
+    string owner = 5;
 }
 
 message GetRuleResponse {
@@ -156,18 +156,19 @@ message DeleteRuleRequest {
 message DeleteRuleResponse {}
 
 message CreateRuleBindingRequest {
-    string object_id = 1;
-    bool cascading = 2;
+    string rule_id = 1;
+    string object_id = 2;
+    bool cascading = 3;
 }
 
 message CreateRuleBindingResponse {
-    string policy_id = 1;
+    string rule_id = 1;
     string object_id = 2;
     bool cascading = 3;
 }
 
 message DeleteRuleBindingRequest {
-    string policy_id = 1;
+    string rule_id = 1;
     string object_id = 2;
 }
 

--- a/aruna/api/storage/services/v2/rules_service.proto
+++ b/aruna/api/storage/services/v2/rules_service.proto
@@ -1,0 +1,174 @@
+syntax = "proto3";
+
+package aruna.api.storage.services.v2;
+option go_package = "github.com/ArunaStorage/go-api/v2/aruna/api/storage/services/v2";
+option java_multiple_files = true;
+option java_package = "com.github.ArunaStorage.java_api.aruna.api.storage.services.v2";
+option java_outer_classname = "RulesService";
+import "aruna/api/storage/models/v2/models.proto";
+import "google/api/annotations.proto";
+
+
+
+// RulesService
+//
+// Status: BETA
+//
+// Contains all methods to edit and change rules
+service RulesService {
+  
+  // CreateRule
+  //
+  // Status: ALPHA
+  //
+  // Create a new rule
+  rpc CreateRule(CreateRuleRequest)
+    returns (CreateRuleResponse) {
+      option (google.api.http) = {
+        post : "/v2/rules"
+        body : "*"
+      };
+  }
+
+  // GetRule
+  //
+  // Status: ALPHA
+  //
+  // Gets an existing rule
+  rpc GetRule(GetRuleRequest)
+    returns (GetRuleResponse) {
+      option (google.api.http) = {
+        get : "/v2/rules/{id}"
+      };
+  }
+
+  // ListRule
+  //
+  // Status: ALPHA
+  //
+  // Lists rules -> Owned and public rules
+  rpc ListRule(ListRuleRequest)
+    returns (ListRuleResponse) {
+      option (google.api.http) = {
+        get : "/v2/rules/list"
+      };
+  }
+
+  // UpdateRule
+  //
+  // Status: ALPHA
+  //
+  // Updates an existing rule
+  rpc UpdateRule(UpdateRuleRequest)
+    returns (UpdateRuleResponse) {
+      option (google.api.http) = {
+        patch : "/v2/rules/{id}"
+        body : "*"
+      };
+  }
+
+  // DeleteRule
+  //
+  // Status: ALPHA
+  //
+  // Deletes an existing rule
+  rpc DeleteRule(DeleteRuleRequest)
+    returns (DeleteRuleResponse) {
+      option (google.api.http) = {
+        delete : "/v2/rules/{id}"
+      };
+  }
+
+  // CreateRuleBinding
+  //
+  // Status: ALPHA
+  //
+  // Associates a rule with an object, optionally cascading the rule to all children
+  rpc CreateRuleBinding(CreateRuleBindingRequest)
+    returns (CreateRuleBindingResponse) {
+      option (google.api.http) = {
+        post : "/v2/rules/{id}/bindings"
+        body : "*"
+      };
+  }
+
+  // DeleteRuleBinding
+  //
+  // Status: ALPHA
+  //
+  // Disassociates a rule from an object
+  rpc DeleteRuleBinding(DeleteRuleBindingRequest)
+    returns (DeleteRuleBindingResponse) {
+      option (google.api.http) = {
+        delete : "/v2/rules/{id}/bindings/{object_id}"
+      };
+  }
+}
+
+
+message CreateRuleRequest {
+    string rule = 1;
+    string description = 2;
+    bool public = 3;
+}
+
+message CreateRuleResponse {
+    string id = 1;
+}
+
+message GetRuleRequest {
+    string id = 1;
+}
+
+message Rule {
+    string id = 1;
+    string rule = 1;
+    string description = 2;
+    bool public = 3;
+    string owner = 4;
+}
+
+message GetRuleResponse {
+    Rule rule = 1;
+}
+
+message ListRuleRequest {}
+
+message ListRuleResponse {
+    repeated Rule rules = 1;
+}
+
+message UpdateRuleRequest {
+    string id = 1;
+    string rule = 2;
+    string description = 3;
+    bool public = 4;
+}
+
+message UpdateRuleResponse {
+    Rule rule = 1;
+}
+
+message DeleteRuleRequest {
+    string id = 1;
+}
+
+message DeleteRuleResponse {}
+
+message CreateRuleBindingRequest {
+    string object_id = 1;
+    bool cascading = 2;
+}
+
+message CreateRuleBindingResponse {
+    string policy_id = 1;
+    string object_id = 2;
+    bool cascading = 3;
+}
+
+message DeleteRuleBindingRequest {
+    string policy_id = 1;
+    string object_id = 2;
+}
+
+message DeleteRuleBindingResponse {}

--- a/aruna/api/storage/services/v2/service_account_service.proto
+++ b/aruna/api/storage/services/v2/service_account_service.proto
@@ -299,7 +299,8 @@ message CreateS3CredentialsSvcAccountResponse {
 }
 
 message GetS3CredentialsSvcAccountRequest {
-  string svc_account_id = 1;
+  // If called as admin, an id must be provided
+  optional string svc_account_id = 1;
   string endpoint_id = 2;
 }
 

--- a/aruna/api/storage/services/v2/service_account_service.proto
+++ b/aruna/api/storage/services/v2/service_account_service.proto
@@ -319,9 +319,11 @@ message DeleteS3CredentialsSvcAccountResponse {}
 
 
 message CreateDataproxyTokenSvcAccountRequest {
-  string svc_account_id = 1;
+  // Needs to be provided by project admins
+  optional string svc_account_id = 1;
+  // optional context to limit the scope 
+  optional storage.models.v2.Context context = 3;
   string endpoint_id = 2;
-  storage.models.v2.Context context = 3;
 }
 
 message CreateDataproxyTokenSvcAccountResponse {

--- a/aruna/api/storage/services/v2/service_account_service.proto
+++ b/aruna/api/storage/services/v2/service_account_service.proto
@@ -116,17 +116,43 @@ service ServiceAccountService {
     };
   }
 
-  // GetS3Credentials
+  // CreateS3CredentialsSvcAccount
   //
   // Status: ALPHA
   //
-  // Gets s3 credentials for a specific SvcAccount and data_proxy
+  // Creates or updates S3 credentials for a specific SvcAccount and data_proxy
+  rpc CreateS3CredentialsSvcAccount(CreateS3CredentialsSvcAccountRequest)
+      returns (CreateS3CredentialsSvcAccountResponse) {
+    option (google.api.http) = {
+      patch : "/v2/service_accounts/{svc_account_id}/s3_credentials/{endpoint_id}"
+    };
+  }
+
+  // GetS3CredentialsSvcAccount
+  //
+  // Status: ALPHA
+  //
+  // Gets S3 credentials for a specific svc_account and data_proxy
   rpc GetS3CredentialsSvcAccount(GetS3CredentialsSvcAccountRequest)
       returns (GetS3CredentialsSvcAccountResponse) {
     option (google.api.http) = {
-      get : "/v2/service_accounts/{svc_account_id}/s3_credentials"
+      get : "/v2/user/s3_credentials/{svc_account_id}/s3_credentials/{endpoint_id}"
     };
   }
+
+  // DeleteS3CredentialsSvcAccount
+  //
+  // Status: ALPHA
+  //
+  // Revokes existing S3 credentials for a specific user and data_proxy
+  rpc DeleteS3CredentialsSvcAccount(DeleteS3CredentialsSvcAccountRequest)
+      returns (DeleteS3CredentialsSvcAccountResponse) {
+    option (google.api.http) = {
+      patch : "/v2/user/s3_credentials/{svc_account_id}/s3_credentials/{endpoint_id}/revoke"
+      body : "*"
+    };
+  }
+
 
   // GetDataproxyToken
   //
@@ -149,7 +175,7 @@ service ServiceAccountService {
   // Adds an ED25519 public key for the SvcAccount
   rpc AddPubkeySvcAccount(AddPubkeySvcAccountRequest) returns (AddPubkeySvcAccountResponse) {
     option (google.api.http) = {
-      post : "/v2/service_accounts/pubkey"
+      post : "/v2/service_accounts/{svc_account_id}/pubkey"
       body : "*"
     };
   }
@@ -161,7 +187,7 @@ service ServiceAccountService {
   // Adds an endpoint to the trusted endpoints list of the SvcAccount
   rpc AddTrustedEndpointsSvcAccount(AddTrustedEndpointsSvcAccountRequest) returns (AddTrustedEndpointsSvcAccountResponse) {
     option (google.api.http) = {
-      post : "/v2/service_accounts/trusted_endpoints"
+      post : "/v2/service_accounts/{svc_account_id}/trusted_endpoints"
       body : "*"
     };
   }
@@ -173,7 +199,7 @@ service ServiceAccountService {
   // Removes an endpoint from the trusted endpoints list of the SvcAccount
   rpc RemoveTrustedEndpointsSvcAccount(RemoveTrustedEndpointsSvcAccountRequest) returns (RemoveTrustedEndpointsSvcAccountResponse) {
     option (google.api.http) = {
-      delete : "/v2/service_accounts/trusted_endpoints"
+      delete : "/v2/service_accounts/{svc_account_id}/trusted_endpoints"
     };
   }
 
@@ -281,6 +307,17 @@ message DeleteServiceAccountRequest {
 message DeleteServiceAccountResponse {}
 
 
+message CreateS3CredentialsSvcAccountRequest {
+  string svc_account_id = 1;
+  string endpoint_id = 2;
+}
+
+message CreateS3CredentialsSvcAccountResponse {
+  string s3_access_key = 1;
+  string s3_secret_key = 2;
+  string s3_endpoint_url = 3;
+}
+
 message GetS3CredentialsSvcAccountRequest {
   string svc_account_id = 1;
   string endpoint_id = 2;
@@ -291,6 +328,13 @@ message GetS3CredentialsSvcAccountResponse {
   string s3_secret_key = 2;
   string s3_endpoint_url = 3;
 }
+
+message DeleteS3CredentialsSvcAccountRequest {
+  string svc_account_id = 1;
+  string endpoint_id = 2;
+}
+
+message DeleteS3CredentialsSvcAccountResponse {}
 
 
 message CreateDataproxyTokenSvcAccountRequest {
@@ -305,19 +349,22 @@ message CreateDataproxyTokenSvcAccountResponse {
 
 
 message AddPubkeySvcAccountRequest {
-  string public_key = 1;
+  string svc_account_id = 1;
+  string public_key = 2;
 }
 
 message AddPubkeySvcAccountResponse {}
 
 message AddTrustedEndpointsSvcAccountRequest {
-  string endpoint_id = 1;
+  string svc_account_id = 1;
+  string endpoint_id = 2;
 }
 
 message AddTrustedEndpointsSvcAccountResponse {}
 
 message RemoveTrustedEndpointsSvcAccountRequest {
-  string endpoint_id = 1;
+  string svc_account_id = 1;
+  string endpoint_id = 2;
 }
 
 message RemoveTrustedEndpointsSvcAccountResponse {}

--- a/aruna/api/storage/services/v2/service_account_service.proto
+++ b/aruna/api/storage/services/v2/service_account_service.proto
@@ -288,7 +288,7 @@ message DeleteServiceAccountResponse {}
 
 
 message CreateS3CredentialsSvcAccountRequest {
-  optional string svc_account_id = 1;
+  string svc_account_id = 1;
   string endpoint_id = 2;
 }
 
@@ -300,7 +300,7 @@ message CreateS3CredentialsSvcAccountResponse {
 
 message GetS3CredentialsSvcAccountRequest {
   // If called as admin, an id must be provided
-  optional string svc_account_id = 1;
+  string svc_account_id = 1;
   string endpoint_id = 2;
 }
 
@@ -311,7 +311,7 @@ message GetS3CredentialsSvcAccountResponse {
 }
 
 message DeleteS3CredentialsSvcAccountRequest {
-  optional string svc_account_id = 1;
+  string svc_account_id = 1;
   string endpoint_id = 2;
 }
 
@@ -320,7 +320,7 @@ message DeleteS3CredentialsSvcAccountResponse {}
 
 message CreateDataproxyTokenSvcAccountRequest {
   // Needs to be provided by project admins
-  optional string svc_account_id = 1;
+  string svc_account_id = 1;
   // optional context to limit the scope 
   optional storage.models.v2.Context context = 3;
   string endpoint_id = 2;

--- a/aruna/api/storage/services/v2/service_account_service.proto
+++ b/aruna/api/storage/services/v2/service_account_service.proto
@@ -46,19 +46,7 @@ service ServiceAccountService {
       body : "*"
     };
   }
-  
-  // SetServiceAccountPermission
-  //
-  // Status: BETA
-  //
-  // Overwrites the project specific permissions for a service account
-  rpc SetServiceAccountPermission(SetServiceAccountPermissionRequest) returns (SetServiceAccountPermissionResponse){
-    option (google.api.http) = {
-      put : "/v2/service_accounts/{svc_account_id}/permissions"
-      body : "*"
-    };
-  }
- 
+
   // GetServiceAccountToken
   //
   // Status: BETA
@@ -229,7 +217,8 @@ service ServiceAccountService {
 
 message CreateServiceAccountRequest {
     string name = 1;
-    storage.models.v2.Permission permission = 2;
+    string project_id = 2;
+    storage.models.v2.PermissionLevel permission_level = 3;
 }
 
 message ServiceAccount {
@@ -244,7 +233,7 @@ message CreateServiceAccountResponse {
 
 message CreateServiceAccountTokenRequest {
     string svc_account_id = 1;
-    // Identify the associated project (should always be provided)
+    // Token permissions
     storage.models.v2.Permission permission = 2;
     // (optional) Token name
     string name = 3;
@@ -257,15 +246,6 @@ message CreateServiceAccountTokenResponse {
     storage.models.v2.Token token = 1;
     // This is the actual secret API token
     string token_secret = 2;
-}
-
-message SetServiceAccountPermissionRequest {
-    string svc_account_id = 1;
-    storage.models.v2.Permission permission = 2;
-}
-
-message SetServiceAccountPermissionResponse {
-    ServiceAccount service_account = 1;
 }
 
 message GetServiceAccountTokenRequest {

--- a/aruna/api/storage/services/v2/service_account_service.proto
+++ b/aruna/api/storage/services/v2/service_account_service.proto
@@ -281,7 +281,7 @@ message DeleteServiceAccountTokensRequest {
 message DeleteServiceAccountTokensResponse {}
 
 message DeleteServiceAccountRequest {
-  optional string svc_account_id = 1;
+  string svc_account_id = 1;
 }
 
 message DeleteServiceAccountResponse {}
@@ -311,7 +311,7 @@ message GetS3CredentialsSvcAccountResponse {
 }
 
 message DeleteS3CredentialsSvcAccountRequest {
-  string svc_account_id = 1;
+  optional string svc_account_id = 1;
   string endpoint_id = 2;
 }
 

--- a/aruna/api/storage/services/v2/service_account_service.proto
+++ b/aruna/api/storage/services/v2/service_account_service.proto
@@ -120,7 +120,7 @@ service ServiceAccountService {
   //
   // Status: ALPHA
   //
-  // Gets s3 credentials for a specific user and data_proxy
+  // Gets s3 credentials for a specific SvcAccount and data_proxy
   rpc GetS3CredentialsSvcAccount(GetS3CredentialsSvcAccountRequest)
       returns (GetS3CredentialsSvcAccountResponse) {
     option (google.api.http) = {
@@ -132,12 +132,71 @@ service ServiceAccountService {
   //
   // Status: ALPHA
   //
-  // Gets token for a specific user and data_proxy
+  // Gets token for a specific SvcAccount and data_proxy
   rpc CreateDataproxyTokenSvcAccount(CreateDataproxyTokenSvcAccountRequest)
       returns (CreateDataproxyTokenSvcAccountResponse) {
     option (google.api.http) = {
       post : "/v2/service_accounts/{svc_account_id}/proxy_tokens/{endpoint_id}"
       body : "*"
+    };
+  }
+
+
+    // AddPubkeySvcAccount
+  //
+  // Status: ALPHA
+  //
+  // Adds an ED25519 public key for the SvcAccount
+  rpc AddPubkeySvcAccount(AddPubkeySvcAccountRequest) returns (AddPubkeySvcAccountResponse) {
+    option (google.api.http) = {
+      post : "/v2/service_accounts/pubkey"
+      body : "*"
+    };
+  }
+
+  // AddTrustedEndpointsSvcAccount
+  //
+  // Status: ALPHA
+  //
+  // Adds an endpoint to the trusted endpoints list of the SvcAccount
+  rpc AddTrustedEndpointsSvcAccount(AddTrustedEndpointsSvcAccountRequest) returns (AddTrustedEndpointsSvcAccountResponse) {
+    option (google.api.http) = {
+      post : "/v2/service_accounts/trusted_endpoints"
+      body : "*"
+    };
+  }
+
+  // RemoveTrustedEndpointsSvcAccount
+  //
+  // Status: ALPHA
+  //
+  // Removes an endpoint from the trusted endpoints list of the SvcAccount
+  rpc RemoveTrustedEndpointsSvcAccount(RemoveTrustedEndpointsSvcAccountRequest) returns (RemoveTrustedEndpointsSvcAccountResponse) {
+    option (google.api.http) = {
+      delete : "/v2/service_accounts/trusted_endpoints"
+    };
+  }
+
+  // AddDataProxyAttributeSvcAccount
+  //
+  // Status: ALPHA
+  //
+  // Adds an data proxy specific attribute to the SvcAccount
+  rpc AddDataProxyAttributeSvcAccount(AddDataProxyAttributeSvcAccountRequest) returns (AddDataProxyAttributeSvcAccountResponse) {
+    option (google.api.http) = {
+      post : "/v2/service_accounts/{svc_account_id}/attributes/data_proxy"
+      body : "*"
+    };
+  }
+
+  // RemoveDataProxyAttributeSvcAccount
+  //
+  // Status: ALPHA
+  //
+  // Removes an data proxy specific attribute from the SvcAccount
+  rpc RemoveDataProxyAttributeSvcAccount(RemoveDataProxyAttributeSvcAccountRequest) returns (RemoveDataProxyAttributeSvcAccountResponse) {
+    option (google.api.http) = {
+      delete : "/v2/service_accounts/{svc_account_id}/attributes/data_proxy"
     };
   }
 }
@@ -243,3 +302,37 @@ message CreateDataproxyTokenSvcAccountRequest {
 message CreateDataproxyTokenSvcAccountResponse {
   string token = 1;
 }
+
+
+message AddPubkeySvcAccountRequest {
+  string public_key = 1;
+}
+
+message AddPubkeySvcAccountResponse {}
+
+message AddTrustedEndpointsSvcAccountRequest {
+  string endpoint_id = 1;
+}
+
+message AddTrustedEndpointsSvcAccountResponse {}
+
+message RemoveTrustedEndpointsSvcAccountRequest {
+  string endpoint_id = 1;
+}
+
+message RemoveTrustedEndpointsSvcAccountResponse {}
+
+message AddDataProxyAttributeSvcAccountRequest {
+  string svc_account_id = 1;
+  storage.models.v2.DataProxyAttribute attribute = 2;
+}
+
+message AddDataProxyAttributeSvcAccountResponse {}
+
+message RemoveDataProxyAttributeSvcAccountRequest {
+  string svc_account_id = 1;
+  string dataproxy_id = 2;
+  string attribute_name = 3;
+}
+
+message RemoveDataProxyAttributeSvcAccountResponse {}

--- a/aruna/api/storage/services/v2/service_account_service.proto
+++ b/aruna/api/storage/services/v2/service_account_service.proto
@@ -281,14 +281,14 @@ message DeleteServiceAccountTokensRequest {
 message DeleteServiceAccountTokensResponse {}
 
 message DeleteServiceAccountRequest {
-    string svc_account_id = 1;
+  optional string svc_account_id = 1;
 }
 
 message DeleteServiceAccountResponse {}
 
 
 message CreateS3CredentialsSvcAccountRequest {
-  string svc_account_id = 1;
+  optional string svc_account_id = 1;
   string endpoint_id = 2;
 }
 

--- a/aruna/api/storage/services/v2/user_service.proto
+++ b/aruna/api/storage/services/v2/user_service.proto
@@ -260,6 +260,65 @@ service UserService {
     };
   }
 
+
+  // AddPubkeyUser
+  //
+  // Status: ALPHA
+  //
+  // Adds an ED25519 public key for the user
+  rpc AddPubkeyUser(AddPubkeyUserRequest) returns (AddPubkeyUserResponse) {
+    option (google.api.http) = {
+      post : "/v2/user/pubkey"
+      body : "*"
+    };
+  }
+
+  // AddTrustedEndpointsUser
+  //
+  // Status: ALPHA
+  //
+  // Adds an endpoint to the trusted endpoints list of the user
+  rpc AddTrustedEndpointsUser(AddTrustedEndpointsUserRequest) returns (AddTrustedEndpointsUserResponse) {
+    option (google.api.http) = {
+      post : "/v2/user/trusted_endpoints"
+      body : "*"
+    };
+  }
+
+  // RemoveTrustedEndpointsUser
+  //
+  // Status: ALPHA
+  //
+  // Removes an endpoint from the trusted endpoints list of the user
+  rpc RemoveTrustedEndpointsUser(RemoveTrustedEndpointsUserRequest) returns (RemoveTrustedEndpointsUserResponse) {
+    option (google.api.http) = {
+      delete : "/v2/user/trusted_endpoints"
+    };
+  }
+
+  // AddDataProxyAttributeUser
+  //
+  // Status: ALPHA
+  //
+  // Adds an data proxy specific attribute to the user
+  rpc AddDataProxyAttributeUser(AddDataProxyAttributeUserRequest) returns (AddDataProxyAttributeUserResponse) {
+    option (google.api.http) = {
+      post : "/v2/user/{user_id}/attributes/data_proxy"
+      body : "*"
+    };
+  }
+
+  // RemoveDataProxyAttributeUser
+  //
+  // Status: ALPHA
+  //
+  // Removes an data proxy specific attribute from the user
+  rpc RemoveDataProxyAttributeUser(RemoveDataProxyAttributeUserRequest) returns (RemoveDataProxyAttributeUserResponse) {
+    option (google.api.http) = {
+      delete : "/v2/user/{user_id}/attributes/data_proxy"
+    };
+  }
+
 }
 
 message RegisterUserRequest {
@@ -475,3 +534,42 @@ message RemoveOidcProviderRequest {
 message RemoveOidcProviderResponse {
   storage.models.v2.User user = 1;
 }
+
+message AddPubkeyUserRequest {
+  string public_key = 1;
+}
+
+message AddPubkeyUserResponse {
+  storage.models.v2.User user = 1;
+}
+
+message AddTrustedEndpointsUserRequest {
+  string endpoint_id = 1;
+}
+
+message AddTrustedEndpointsUserResponse {
+  storage.models.v2.User user = 1;
+}
+
+message RemoveTrustedEndpointsUserRequest {
+  string endpoint_id = 1;
+}
+
+message RemoveTrustedEndpointsUserResponse {
+  storage.models.v2.User user = 1;
+}
+
+message AddDataProxyAttributeUserRequest {
+  string user_id = 1;
+  storage.models.v2.DataProxyAttribute attribute = 2;
+}
+
+message AddDataProxyAttributeUserResponse {}
+
+message RemoveDataProxyAttributeUserRequest {
+  string user_id = 1;
+  string dataproxy_id = 2;
+  string attribute_name = 3;
+}
+
+message RemoveDataProxyAttributeUserResponse {}

--- a/aruna/api/storage/services/v2/user_service.proto
+++ b/aruna/api/storage/services/v2/user_service.proto
@@ -187,15 +187,41 @@ service UserService {
     };
   }
 
-  // GetS3Credentials
+
+  // CreateS3CredentialsUserToken
   //
   // Status: ALPHA
   //
-  // Gets s3 credentials for a specific user and data_proxy
-  rpc GetS3CredentialsUser(GetS3CredentialsUserRequest)
-      returns (GetS3CredentialsUserResponse) {
+  // Creates or updates S3 credentials for a specific user and data_proxy
+  rpc CreateS3CredentialsUserToken(CreateS3CredentialsUserTokenRequest)
+      returns (CreateS3CredentialsUserTokenResponse) {
     option (google.api.http) = {
-      get : "/v2/user/{user_id}/s3_credentials"
+      patch : "/v2/user/s3_credentials/{endpoint_id}"
+    };
+  }
+
+  // GetS3CredentialsUserToken
+  //
+  // Status: ALPHA
+  //
+  // Gets S3 credentials for a specific token and data_proxy
+  rpc GetS3CredentialsUserToken(GetS3CredentialsUserTokenRequest)
+      returns (GetS3CredentialsUserTokenResponse) {
+    option (google.api.http) = {
+      get : "/v2/user/s3_credentials/{endpoint_id}"
+    };
+  }
+
+  // DeleteS3CredentialsUserToken
+  //
+  // Status: ALPHA
+  //
+  // Revokes existing S3 credentials for a specific user and data_proxy
+  rpc DeleteS3CredentialsUserToken(DeleteS3CredentialsUserTokenRequest)
+      returns (DeleteS3CredentialsUserResponse) {
+    option (google.api.http) = {
+      patch : "/v2/user/s3_credentials/{endpoint_id}/revoke"
+      body : "*"
     };
   }
 
@@ -207,7 +233,7 @@ service UserService {
   rpc GetDataproxyTokenUser(GetDataproxyTokenUserRequest)
       returns (GetDataproxyTokenUserResponse) {
     option (google.api.http) = {
-      get : "/v2/user/{user_id}/proxy_token"
+      get : "/v2/user/proxy_token"
     };
   }
 
@@ -231,7 +257,8 @@ service UserService {
   rpc AcknowledgePersonalNotifications(AcknowledgePersonalNotificationsRequest)
       returns (AcknowledgePersonalNotificationsResponse) {
     option (google.api.http) = {
-      get : "/v2/user/notifications/acknowledge"
+      post : "/v2/user/notifications/acknowledge"
+      body : "*"
     };
   }
 
@@ -268,7 +295,7 @@ service UserService {
   // Adds an ED25519 public key for the user
   rpc AddPubkeyUser(AddPubkeyUserRequest) returns (AddPubkeyUserResponse) {
     option (google.api.http) = {
-      post : "/v2/user/pubkey"
+      patch : "/v2/user/pubkey"
       body : "*"
     };
   }
@@ -280,7 +307,7 @@ service UserService {
   // Adds an endpoint to the trusted endpoints list of the user
   rpc AddTrustedEndpointsUser(AddTrustedEndpointsUserRequest) returns (AddTrustedEndpointsUserResponse) {
     option (google.api.http) = {
-      post : "/v2/user/trusted_endpoints"
+      patch : "/v2/user/trusted_endpoints"
       body : "*"
     };
   }
@@ -303,7 +330,7 @@ service UserService {
   // Adds an data proxy specific attribute to the user
   rpc AddDataProxyAttributeUser(AddDataProxyAttributeUserRequest) returns (AddDataProxyAttributeUserResponse) {
     option (google.api.http) = {
-      post : "/v2/user/{user_id}/attributes/data_proxy"
+      patch : "/v2/user/{user_id}/attributes/data_proxy"
       body : "*"
     };
   }
@@ -458,16 +485,31 @@ message UpdateUserEmailResponse {
   storage.models.v2.User user = 1;
 }
 
-message GetS3CredentialsUserRequest {
-  string user_id = 1;
-  string endpoint_id = 2;
+message CreateS3CredentialsUserTokenRequest {
+  string endpoint_id = 1;
 }
 
-message GetS3CredentialsUserResponse {
+message CreateS3CredentialsUserTokenResponse {
   string s3_access_key = 1;
   string s3_secret_key = 2;
   string s3_endpoint_url = 3;
 }
+
+message GetS3CredentialsUserTokenRequest {
+  string endpoint_id = 1;
+}
+
+message GetS3CredentialsUserTokenResponse {
+  string s3_access_key = 1;
+  string s3_secret_key = 2;
+  string s3_endpoint_url = 3;
+}
+
+message DeleteS3CredentialsUserTokenRequest {
+  string endpoint_id = 1;
+}
+
+message DeleteS3CredentialsUserResponse {}
 
 message GetDataproxyTokenUserRequest {
   string user_id = 1;
@@ -549,6 +591,8 @@ message AddTrustedEndpointsUserRequest {
 
 message AddTrustedEndpointsUserResponse {
   storage.models.v2.User user = 1;
+  // Here would be the place to add conditions
+  // why the request was denied
 }
 
 message RemoveTrustedEndpointsUserRequest {

--- a/aruna/api/storage/services/v2/workspace_service.proto
+++ b/aruna/api/storage/services/v2/workspace_service.proto
@@ -121,6 +121,8 @@ message CreateWorkspaceTemplateRequest {
   string description = 6;
   // Endpoint ids that are used for this template
   repeated string endpoint_ids = 7;
+  // Rule ids that are enforced on workspace-level
+  repeated string rules = 8;
 }
 
 message CreateWorkspaceTemplateResponse {


### PR DESCRIPTION
# Summary
Adds main features needed for a final release. This includes changes needed for the data proxy overhaul, server side rules and missing fields for objects and users.

# Changes
- Splitting `GetS3Credentials` into `Get/Create/DeleteS3Credentials` on server and proxy side.
- Adding data proxy file ingestion
- `PullReplication` rework to efficiently use pithos file format as a replication protocol
- First and last name fields for users
- Data proxy specific attributes for users
- A pubkey field for users
- Author & title fields for objects
- Rules & rule bindings for resources including workspaces
- Update requests for added fields
- A `SetObjectHashes` function that either adds new hashes or compares hashes
- A rule service to create and update rules for resources