### PR TITLE
Extend public announcements

### DIFF
--- a/aruna/api/storage/models/v2/models.proto
+++ b/aruna/api/storage/models/v2/models.proto
@@ -8,10 +8,11 @@ package aruna.api.storage.models.v2;
 // Defines the public announcement type
 enum AnnouncementType {
   ANNOUNCEMENT_TYPE_UNSPECIFIED = 0;
-  ANNOUNCEMENT_TYPE_MISC = 1;
+  ANNOUNCEMENT_TYPE_ORGA = 1;
   ANNOUNCEMENT_TYPE_RELEASE = 2;
   ANNOUNCEMENT_TYPE_UPDATE = 3;
   ANNOUNCEMENT_TYPE_MAINTENANCE = 4;
+  ANNOUNCEMENT_TYPE_BLOG = 5;
 }
 
 // Dataclass defines the confidentiality of the object

--- a/aruna/api/storage/models/v2/models.proto
+++ b/aruna/api/storage/models/v2/models.proto
@@ -5,6 +5,14 @@ option go_package = "github.com/ArunaStorage/go-api/v2/aruna/api/storage/models/
 package aruna.api.storage.models.v2;
 
 // --------------- ENUMS ------------------------
+// Defines the public announcement type
+enum AnnouncementType {
+  ANNOUNCEMENT_TYPE_UNSPECIFIED = 0;
+  ANNOUNCEMENT_TYPE_MISC = 1;
+  ANNOUNCEMENT_TYPE_RELEASE = 2;
+  ANNOUNCEMENT_TYPE_UPDATE = 3;
+  ANNOUNCEMENT_TYPE_MAINTENANCE = 4;
+}
 
 // Dataclass defines the confidentiality of the object
 enum DataClass {

--- a/aruna/api/storage/services/v2/info_service.proto
+++ b/aruna/api/storage/services/v2/info_service.proto
@@ -146,11 +146,21 @@ message Announcement {
   string announcement_id = 1;
   storage.models.v2.AnnouncementType announcement_type = 2;
   string title = 3;
-  string content = 4;
-  string created_by = 5;
-  google.protobuf.Timestamp created_at = 6;
-  string modified_by = 7;
-  google.protobuf.Timestamp modified_at = 8;
+  string teaser = 4;
+  string content = 5;
+  string created_by = 6;
+  google.protobuf.Timestamp created_at = 7;
+  string modified_by = 8;
+  google.protobuf.Timestamp modified_at = 9;
+}
+
+message SetAnnouncementsRequest {
+  repeated Announcement announcements_upsert = 1;
+  repeated string announcements_delete = 2;
+}
+
+message SetAnnouncementsResponse {
+  repeated Announcement announcements = 1;
 }
 
 message GetAnnouncementsRequest {}
@@ -165,13 +175,4 @@ message GetAnnouncementRequest {
 
 message GetAnnouncementResponse {
   Announcement announcement = 1;
-}
-
-message SetAnnouncementsRequest {
-  repeated Announcement announcements_upsert = 1;
-  repeated string announcements_delete = 2;
-}
-
-message SetAnnouncementsResponse {
-  repeated Announcement announcements = 1;
 }

--- a/aruna/api/storage/services/v2/info_service.proto
+++ b/aruna/api/storage/services/v2/info_service.proto
@@ -163,7 +163,9 @@ message SetAnnouncementsResponse {
   repeated Announcement announcements = 1;
 }
 
-message GetAnnouncementsRequest {}
+message GetAnnouncementsRequest {
+  storage.models.v2.PageRequest page = 1;
+}
 
 message GetAnnouncementsResponse {
   repeated Announcement announcements = 1;

--- a/aruna/api/storage/services/v2/info_service.proto
+++ b/aruna/api/storage/services/v2/info_service.proto
@@ -132,9 +132,14 @@ message GetPubkeysResponse {
 }
 
 message Announcement {
-  string id = 1;
-  string content = 2;
-  google.protobuf.Timestamp created_at = 3;
+  string announcement_id = 1;
+  storage.models.v2.AnnouncementType announcement_type = 2;
+  string title = 3;
+  string content = 4;
+  string created_by = 5;
+  google.protobuf.Timestamp created_at = 6;
+  string modified_by = 7;
+  google.protobuf.Timestamp modified_at = 8;
 }
 
 message GetAnnouncementsRequest {}

--- a/aruna/api/storage/services/v2/info_service.proto
+++ b/aruna/api/storage/services/v2/info_service.proto
@@ -53,11 +53,13 @@ service StorageStatusService {
     };
   }
 
-  // GetAnnouncements
+  // Get Announcements
   //
   // Status: BETA
   //
-  // Query global announcements
+  // Query global announcements optionally filtered by specific ids. 
+  //  - Returns all announcements if no ids are provided
+  //  - Returns only the specific announcements if ids are provided
   rpc GetAnnouncements(GetAnnouncementsRequest) returns (GetAnnouncementsResponse) {
     option (google.api.http) = {
       get : "/v2/info/announcements"
@@ -164,7 +166,8 @@ message SetAnnouncementsResponse {
 }
 
 message GetAnnouncementsRequest {
-  storage.models.v2.PageRequest page = 1;
+  repeated string announcement_ids = 1;
+  storage.models.v2.PageRequest page = 2;
 }
 
 message GetAnnouncementsResponse {

--- a/aruna/api/storage/services/v2/info_service.proto
+++ b/aruna/api/storage/services/v2/info_service.proto
@@ -160,7 +160,7 @@ message GetAnnouncementsResponse {
 }
 
 message GetAnnouncementRequest {
-  string id = 1;
+  string announcement_id = 1;
 }
 
 message GetAnnouncementResponse {

--- a/aruna/api/storage/services/v2/info_service.proto
+++ b/aruna/api/storage/services/v2/info_service.proto
@@ -66,11 +66,22 @@ service StorageStatusService {
     };
   }
 
-    // GetAnnouncement
+  // GetAnnouncementsByType
   //
   // Status: BETA
   //
-  // Query a specific global announcement
+  // Query global announcements by type
+  rpc GetAnnouncementsByType(GetAnnouncementsByTypeRequest) returns (GetAnnouncementsByTypeResponse) {
+    option (google.api.http) = {
+      get : "/v2/info/announcements/{announcement_type}"
+    };
+  }
+
+  // Get a specific Announcement
+  //
+  // Status: BETA
+  //
+  // Query a specific global announcement by its id
   rpc GetAnnouncement(GetAnnouncementRequest) returns (GetAnnouncementResponse) {
     option (google.api.http) = {
       get : "/v2/info/announcements/{announcement_id}"
@@ -144,6 +155,9 @@ message GetPubkeysResponse {
   repeated storage.models.v2.Pubkey pubkeys = 1;
 }
 
+/* -------------------------------------*/
+/* ----- Public Announcements ----------*/
+/* -------------------------------------*/
 message Announcement {
   string announcement_id = 1;
   storage.models.v2.AnnouncementType announcement_type = 2;
@@ -171,6 +185,15 @@ message GetAnnouncementsRequest {
 }
 
 message GetAnnouncementsResponse {
+  repeated Announcement announcements = 1;
+}
+
+message GetAnnouncementsByTypeRequest {
+  storage.models.v2.AnnouncementType announcement_type = 1;
+  storage.models.v2.PageRequest page = 2;
+}
+
+message GetAnnouncementsByTypeResponse {
   repeated Announcement announcements = 1;
 }
 

--- a/aruna/api/storage/services/v2/info_service.proto
+++ b/aruna/api/storage/services/v2/info_service.proto
@@ -64,6 +64,17 @@ service StorageStatusService {
     };
   }
 
+    // GetAnnouncement
+  //
+  // Status: BETA
+  //
+  // Query a specific global announcement
+  rpc GetAnnouncement(GetAnnouncementRequest) returns (GetAnnouncementResponse) {
+    option (google.api.http) = {
+      get : "/v2/info/announcements/{announcement_id}"
+    };
+  }
+
   // SetAnnouncements
   //
   // Status: BETA
@@ -146,6 +157,14 @@ message GetAnnouncementsRequest {}
 
 message GetAnnouncementsResponse {
   repeated Announcement announcements = 1;
+}
+
+message GetAnnouncementRequest {
+  string id = 1;
+}
+
+message GetAnnouncementResponse {
+  Announcement announcement = 1;
 }
 
 message SetAnnouncementsRequest {


### PR DESCRIPTION
This pull request introduces enhancements to the API for public announcements within the `StorageStatusService` by extending the `Announcement` message with the following fields:

* `announcement_type`: A non-exhaustive type to differentiate announcements
* `title`: A title for the announcement
* `teaser`: A short summary of the announcement
* `created_by`: An id or display name of the original author
* `modified_by`: An id or display name of the last person that modified the announcement
* `modified_at`: Timestamp of the last modification

In addition, the `StorageStatusService` gets extended by the following 

* Extended endpoint `GetAnnouncements` with an optional id filter
* New endpoint `GetAnnouncement`, which enables the specific query of an announcement based on its id
* New endpoint `GetAnnouncementsByType`, which enables to query all announcements of a specific type
* Pagination for all `StorageStatusService` GET Requests

These extensions will offer users of the API more flexibility in how they can display public announcements, regardless of whether it's just a small timeline or a proper blog.