### PR TITLE
Add preview image url field to Announcement

### DIFF
--- a/aruna/api/storage/services/v2/info_service.proto
+++ b/aruna/api/storage/services/v2/info_service.proto
@@ -159,15 +159,16 @@ message GetPubkeysResponse {
 /* ----- Public Announcements ----------*/
 /* -------------------------------------*/
 message Announcement {
-  string announcement_id = 1;
-  storage.models.v2.AnnouncementType announcement_type = 2;
-  string title = 3;
-  string teaser = 4;
-  string content = 5;
-  string created_by = 6;
-  google.protobuf.Timestamp created_at = 7;
-  string modified_by = 8;
-  google.protobuf.Timestamp modified_at = 9;
+  string announcement_id = 1; // Announcement id
+  storage.models.v2.AnnouncementType announcement_type = 2; // Announcement type
+  string title = 3;      // Announcement title
+  string teaser = 4;     // Short announcement summary
+  string image_url = 5;  // URL for announcement preview image
+  string content = 6;    // Announcement content text
+  string created_by = 7; // Initial announcement author
+  google.protobuf.Timestamp created_at = 8; // Initial creation timestamp
+  string modified_by = 9; // Author responsible for the last modification
+  google.protobuf.Timestamp modified_at = 10; // Last modification timestamp
 }
 
 message SetAnnouncementsRequest {


### PR DESCRIPTION
This extends the `Announcement` message by adding an additional field `image_url`. This field will provide the URL of a preview image, allowing announcements display to include visual content for better engagement and context. The change aims to improve the user experience by providing a richer, more informative announcement display.