### PR TITLE
Add upload_id to FinishObjectStagingRequest

### DIFF
--- a/aruna/api/storage/services/v2/object_service.proto
+++ b/aruna/api/storage/services/v2/object_service.proto
@@ -258,6 +258,11 @@ message FinishObjectStagingRequest {
   // Should be empty if the upload was not multipart.
   // (optional)
   repeated CompletedPart completed_parts = 4;
+
+  // If the upload was multipart, this is the upload id which should be completed.
+  // Should be empty if the upload was not multipart.
+  // (optional)
+  string upload_id = 5;
 }
 
 message FinishObjectStagingResponse {


### PR DESCRIPTION
This pull request introduces an extension to the `FinishObjectStagingRequest` by adding the `upload_id` field. This extension addresses the issue that an upload id generated for a multipart upload needs to be provided if a user wants to manually signal the completion of a multipart upload to the Aruna Server.